### PR TITLE
chore: add portal bitcoin

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -661,3 +661,4 @@ Froggo,Froggo,A12XggFFk3b5GCd6ZYxuQ55cQbxarHL4h7Jxs3GQcdC3,9,https://froggotoken
 Slow Protocol,SLOW,2KE2UNJKB6RGgb78DxJbi2HXSfCs1EocHj4FDMZPr4HA,5,https://t3wsqd23o7n5d2pjgvspqafxi3jcznjfrdgwkh6acmgf3zjpnsgq.arweave.net/nu0oD1t329Hp6TVk-AC3RtIstSWIzWUfwBMMXeUvbI0,true
 BAT,BATT,BzjsQpgKjxZedFawUV9GZMExhr7VbvsasQv12v2PVxSt,8,https://batt.finance/static/media/logo.6284c2cd472e1bacd3e5c370044f6a0e.svg,true
 BIU COIN,BIU,4D7kEovLBEY3VQUzJUQjXyGR8fAZwQWSxEcsP5Y9nZ6S,9,https://biucoin.club/img/cat.png,true
+Wrapped BTC (Portal),WBTC,3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh,8,https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh/logo.png,true


### PR DESCRIPTION
- portal bitcoin don't have an onchain token info, it can be found in this list https://raw.githubusercontent.com/certusone/wormhole-token-list/main/content/by_dest.csv

# Validate [Token Symbol](https://solscan.io/token/3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh)

## Attestations:
- Tweet with Mint address: N/A
- Coingecko/ CMC URL (If available): https://www.coingecko.com/en/coins/wrapped-bitcoin

## Validation (Additonal material for reviewers):
- [ ] The metadata provided in the PR matches what is on-chain (Mandatory), This token is from legacy list and don't have onchain token data
- [x] Does not duplicate the symbol of another token on Jupiter's strict list (If not, review will take longer)
- [x] Is Listed on Coingecko / CMC (Optional, but might be helpful for reviewers to check for duplicates)  

## Acknowledgement
- [x] Acknowleged that I did not modify unrelated code.
- [x] Acknowledged that my change matches the format of other lines in the file (no spaces between fields). 
