### PR TITLE
Fix broken links (blog post & api docs) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Our design principles are: Safety, Openness, Unopinionated, Collaborative, Commu
 
 Learn more:
 -  [Tweet](https://twitter.com/JupiterExchange/status/1625877026866446337?s=20)
--  [Blog post](https://blog.jup.ag/token-list-api/)
--  [API docs](https://station.jup.ag/docs/apis/token-list-api)
+-  [Blog post](https://station.jup.ag/blog/jupiter-token-list-api)
+-  [API docs](https://station.jup.ag/docs/token-list/token-list-api)
 -  [Getting on the Strict list docs](https://station.jup.ag/docs/get-your-token-onto-jup#getting-on-the-strict-list)
 
 ## Address Validation into 'Strict' List:


### PR DESCRIPTION
This PR fixes two broken links in the `README.md`.