### PR TITLE
Validate zippySOL - liquid staking token from Zippy Stake Pool

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -1073,3 +1073,4 @@ BOZO,$BOZO,BoZoQQRAmYkr5iJhqo7DChAs7DPDwEZ5cv1vkYC9yzJG,5,https://arweave.net/QN
 Pax Dollar,USDP,HVbpJAQGNpkgBaYBZQBR1t7yFdvaYVp2vCQQfKKEN4tM,6,https://424565.fs1.hubspotusercontent-na1.net/hubfs/424565/USDPLOGO.png,true
 Saros,SAROS,SarosY6Vscao718M4A778z4CGtvcwcGef5M9MEH1LGL,6,https://rapid.coin98.com/Currency/saros.png,true
 MMOSH: The Stoked Token,MMOSH,FwfrwnNVLGyS8ucVjWvyoRdFDpTY8w6ACMAxJ4rqGUSS,9,https://shdw-drive.genesysgo.net/7nPP797RprCMJaSXsyoTiFvMZVQ6y1dUgobvczdWGd35/MMoshCoin.png,true
+Zippy Staked SOL,zippySOL,Zippybh3S5xYYam2nvL6hVJKz1got6ShgV4DyD1XQYF,9,https://www.zippystake.org/mint.png,true


### PR DESCRIPTION
# Validate [zippySOL](https://solscan.io/token/Zippybh3S5xYYam2nvL6hVJKz1got6ShgV4DyD1XQYF)

## Attestations (Please provide links):
- Tweet from your Twitter Account attesting the Mint address, tagging [@JupiterExchange](https://twitter.com/JupiterExchange) and showing community support: https://x.com/ZippyStake/status/1749468707418415280?s=20
- Coingecko/ CMC URL (If available): PENDING

## Validation (Please check off boxes):
- [x] The metadata provided in the PR matches what is on-chain (Mandatory)
- [x] Does not duplicate the symbol of another token on Jupiter's strict list (If not, review will be delayed)
- [ ] Is Listed on Coingecko / CMC (Optional, but helpful for reviewers)  PENDING

## Acknowledgement (Please check off boxes)
- [x] My change matches the format in the file (no spaces between fields).
- [x] My token is already live and trading on Jupiter (using Meteora DLMM)
- [x] !!! I read the README section on Community-Driven Validation and understand this PR will be only be reviewed when there is community support on Twitter.
- [x] Please make sure your pull request title has your token name. If it just says "Main", or "Validate", it will automatically be closed. PRs containing broken attestation or solscan links will also be closed.

## Additional information:

zippySOL is a liquid staking token for the Zippy Stake Pool (www.zippystake.org) and as such it carries an intrinsic utility. When you stake/deposit your SOL into the Zippy Stake Pool, you get a zippySOL in return which you can then use for unstaking at a later date. The value is zippySOL is tied to SOL and increases every epoch. The Zippy Stake Pool uses the standard SPL stake-pool program, e.g. like Jito does.