### PR TITLE
added check isSymbolConfusing()

### DIFF
--- a/src/logic.ts
+++ b/src/logic.ts
@@ -1,6 +1,6 @@
 import * as core from "@actions/core";
 import { exec } from "@actions/exec";
-import { detectDuplicateSymbol, detectDuplicateMints, canOnlyAddOneToken, validMintAddress, noEditsToPreviousLinesAllowed, isCommunityValidated } from "./utils/validate";
+import { detectDuplicateSymbol, detectDuplicateMints, canOnlyAddOneToken, validMintAddress, noEditsToPreviousLinesAllowed, isCommunityValidated, isSymbolConfusing } from "./utils/validate";
 import { ValidatedTokensData } from "./types/types";
 import { indexToLineNumber } from "./utils/validate";
 import { parse } from "csv-parse/sync";
@@ -20,6 +20,7 @@ export async function validateValidatedTokensCsv(filename: string): Promise<numb
     let invalidMintAddresses;
     let notCommunityValidated;
     let noEditsAllowed;
+    let potentiallyConfusingSymbols;
 
     duplicateSymbols = detectDuplicateSymbol(recordsPrevious, records);
     duplicateMints = detectDuplicateMints(records);
@@ -27,6 +28,7 @@ export async function validateValidatedTokensCsv(filename: string): Promise<numb
     invalidMintAddresses = validMintAddress(records);
     noEditsAllowed = noEditsToPreviousLinesAllowed(recordsPrevious, records);
     notCommunityValidated = isCommunityValidated(records);
+    potentiallyConfusingSymbols = isSymbolConfusing(recordsPrevious, records);
 
     console.log("No More Duplicate Symbols:", duplicateSymbols, `(${allowedDuplicateSymbols.length} exceptions)`);
     console.log("Duplicate Mints:", duplicateMints);
@@ -34,6 +36,7 @@ export async function validateValidatedTokensCsv(filename: string): Promise<numb
     console.log("Invalid Mint Addresses:", invalidMintAddresses);
     console.log("Not Community Validated:", notCommunityValidated, `(${allowedNotCommunityValidated.length} exceptions)`);
     console.log("Edits to Existing Tokens:", noEditsAllowed);
+    console.log("Issues with Symbols in Added Tokens:", potentiallyConfusingSymbols);
     return (duplicateSymbols + duplicateMints + attemptsToAddMultipleTokens + invalidMintAddresses + noEditsAllowed)
 }
 

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -56,14 +56,14 @@ export function detectDuplicateSymbol(tokensPreviously: ValidatedTokensData[], t
       .map((token) => token.Symbol)
       .sort()
 
-    const theNewDuplicateSymbol = xorTokens(duplicateSymbols, allowedDuplicateSymbols)
+    const theNewDuplicateSymbol = xorTokensWithExceptions(duplicateSymbols, allowedDuplicateSymbols)
     console.log(ValidationError.DUPLICATE_SYMBOL, theNewDuplicateSymbol);
     console.log(`(the last version of the CSV file had ${duplicateSymbolsPrev.length} duplicates)`)
   }
   return duplicateSymbols.length - allowedDuplicateSymbols.length;
 }
 
-function xorTokens(tokens: ValidatedTokensData[], allowedDuplicates: AllowedException[]): ValidatedTokensData[] {
+function xorTokensWithExceptions(tokens: ValidatedTokensData[], allowedDuplicates: AllowedException[]): ValidatedTokensData[] {
   const tokensSymbolMint = tokens.map((token) => `${token.Symbol}-${token.Mint}`).sort();
   const allowedDuplicatesSymbolMint = allowedDuplicates.map((token) => `${token.Symbol}-${token.Mint}`).sort();
 
@@ -85,6 +85,57 @@ function xorTokens(tokens: ValidatedTokensData[], allowedDuplicates: AllowedExce
   }
   return answer
 };
+
+export function isSymbolConfusing(tokensPreviously: ValidatedTokensData[], tokens: ValidatedTokensData[]): number {
+  let problems = 0;
+  const newTokens = xor(tokensPreviously, tokens);
+
+  // please no more weird symbols. Only alphanumeric, no $/- pre/suffixes, and certainly no emojis either
+  const REGEX_NON_ALPHANUMERIC = /[^a-zA-Z0-9]/;
+  newTokens.forEach((token) => {
+    if (REGEX_NON_ALPHANUMERIC.test(token.Symbol)) {
+      problems++;
+      console.log("Encourage symbols to stick to alphanumerics and not include any funny characters. Definitely no emojis. Case in point:", token)
+    }
+  })
+
+  // is the new name eerily similar to something else we have before? e.g. $BOZO and BOZO
+  const existingSymbols = tokensPreviously.map((token) => token.Symbol)
+  newTokens.forEach((newToken) => {
+    const sanitizedNewTokenSymbol = trimNonAlphanumeric(newToken.Symbol)
+    const match = existingSymbols.find(existingSymbol => existingSymbol.includes(sanitizedNewTokenSymbol))
+    if (match) {
+      problems++;
+      console.log(`incoming token ${newToken.Symbol} (sanitized: ${sanitizedNewTokenSymbol}) is similar to an existing symbol ${match}, advise them to change`)
+    }
+  });
+  return problems
+}
+
+// xor finds the new tokens that were added
+function xor(tokensPreviously: ValidatedTokensData[], tokens: ValidatedTokensData[]):  ValidatedTokensData[] {
+  const answer: ValidatedTokensData[] = [];
+  const byMint = new Map();
+  tokensPreviously.forEach((token) => {
+    if (!byMint.has(token.Mint)) {
+      byMint.set(token.Mint, token);
+    } else {
+      console.log("xor(): FATAL ERROR: You're not supposed to have duplicate mints!", token, byMint.get(token.Mint))
+    }
+  })
+
+  tokens.forEach((token) => {
+    if (!byMint.has(token.Mint)) {
+      answer.push(token)
+    }
+  })
+  return answer;
+}
+
+// trimNonAlphanumeric turns "*hello world!*&(%" into "hello world"
+function trimNonAlphanumeric(str: string): string {
+  return str.replace(/(^\W+)|(\W+$)/g, "");
+}
 
 export function canOnlyAddOneToken(prevTokens: ValidatedTokensData[], tokens: ValidatedTokensData[]): number {
   let errorCount = 0;


### PR DESCRIPTION
which ensures that symbols won't have non-alphanumeric characters and aren't too similar to existing ones

Sample output:
```
Encourage symbols to stick to alphanumerics and not include any funny characters. Definitely no emojis. Case in point: {
  Name: 'anotherBOZO',
  Symbol: '-BOZO-',
  ...
}
incoming token -BOZO- (sanitized: BOZO) is similar to an existing symbol $BOZO, advise them to change
No More Duplicate Symbols: 0 (18 exceptions)
Duplicate Mints: 0
Attempts to Add Multiple Tokens: 0
Invalid Mint Addresses: 0
Not Community Validated: 0 (612 exceptions)
Edits to Existing Tokens: 0
Issues with Symbols in Added Tokens: 2 <========== NEW
```