### PR TITLE
better error message when the onchain meta points to a JSON that poin…

### DIFF
--- a/src/utils/validate.spec.ts
+++ b/src/utils/validate.spec.ts
@@ -90,5 +90,19 @@ test('newTokensHaveMatchingOnchainMeta() errors if the mint doesn\'t exist', asy
     const connection = new Connection(clusterApiUrl("mainnet-beta"));
     let mismatches = await newTokensHaveMatchingOnchainMeta(connection, tokens);
     expect(mismatches).toEqual(1);
-
+});
+test('newTokensHaveMatchingOnchainMeta() should point out, if the onchain LogoURI doesn\'t match the CSV, that the onchain linked to a JSON which had the actual image link', async () => {
+    const fake: ValidatedTokensData = {
+        Name: "You Looked",
+        Symbol: "CIRCLE",
+        Mint: "EkHr62PC6Y1axrLS7cR8YC4BZeW19mtHxQLCLMrf9vnq",
+        Decimals: "3",
+        LogoURI: "https://i.imgur.com/fEFVS51.png", // they submitted this link, but the onchain JSON links to a different image link
+        Line: 1,
+        "Community Validated": true,
+    }
+    const tokens = [fake];
+    const connection = new Connection(clusterApiUrl("mainnet-beta"));
+    let mismatches = await newTokensHaveMatchingOnchainMeta(connection, tokens);
+    expect(mismatches).toEqual(1);
 });

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -266,18 +266,25 @@ export async function newTokensHaveMatchingOnchainMeta(connection: Connection, n
       // what a mess. On-chain metadata URIs are actually a JSON to a URL
       // which has the actual Logo URL. So we have to try and fetch before we
       // make an actual comparison.
+      let newLogoURI = null;
       if (metadata.uri !== newToken.LogoURI) {
         let uriMismatch = true; // Assume there's a mismatch initially
         // it might be a JSON. Let's try to fetch it and see if it has an image key
         if (await checkContentType(metadata.uri) === 'application/json') {
-          const newLogoURI = await getLogoURIFromJson(metadata.uri);
+          newLogoURI = await getLogoURIFromJson(metadata.uri);
           if (newLogoURI === newToken.LogoURI) {
             uriMismatch = false; // The URIs match after fetching the JSON, so no mismatch
           }
         }
 
         if (uriMismatch) {
-          console.log(`${ValidationError.INVALID_METADATA}: ${newToken.Mint} URI mismatch Expected: ${newToken.LogoURI}, Found: ${metadata.uri}`);
+          let errorMessage = `${ValidationError.INVALID_METADATA}: ${newToken.Mint} URI mismatch CSV: ${newToken.LogoURI}, Onchain: `;
+          if (newLogoURI) {
+            errorMessage += `JSON ${metadata.uri} which points to ${newLogoURI}`;
+          } else {
+            errorMessage += `${metadata.uri}`;
+          }
+          console.log(errorMessage);
           errors += 1;
         }
       }

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -278,9 +278,9 @@ export async function newTokensHaveMatchingOnchainMeta(connection: Connection, n
         }
 
         if (uriMismatch) {
-          let errorMessage = `${ValidationError.INVALID_METADATA}: ${newToken.Mint} URI mismatch CSV: ${newToken.LogoURI}, Onchain: `;
+          let errorMessage = `${ValidationError.INVALID_METADATA}: ${newToken.Mint} URI mismatch Expected: ${newToken.LogoURI}, Found Onchain: `;
           if (newLogoURI) {
-            errorMessage += `JSON ${metadata.uri} which points to ${newLogoURI}`;
+            errorMessage += `${newLogoURI} (from JSON ${metadata.uri})`;
           } else {
             errorMessage += `${metadata.uri}`;
           }


### PR DESCRIPTION
…ts to the logo uri

```
stdout | src/utils/validate.spec.ts > newTokensHaveMatchingOnchainMeta() should point out, if the onchain LogoURI doesn't match the CSV, that the onchain linked to a JSON which had the actual image link
Metadata does not match on-chain data: EkHr62PC6Y1axrLS7cR8YC4BZeW19mtHxQLCLMrf9vnq URI mismatch CSV: https://i.imgur.com/fEFVS51.png, Onchain: JSON https://gateway.irys.xyz/nQxhYzysaPBeX58YrBWTYvCXFXB-brrmvkGLvD2tPDQ which points to https://gateway.irys.xyz/gcHO4HXSSGvzSMKMnXmMmkK5Brmy4iUOmW6Wjz0Wr_E
```