### PR TITLE
Update PAINT image url in validated-tokens.csv

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -1093,7 +1093,7 @@ Elementerra,ELE,8A9HYfj9WAMgjxARWVCJHAeq9i8vdN9cerBmqUamDj7U,9,https://elementer
 Bozo Hybrid,bozoHYBRID,EJPtJEDogxzDbvM8qvAsqYbLmPj5n1vQeqoAzj9Yfv3q,9,https://bafkreiamobqahwlwio5syavvfkknvfecgt7osbsh2s4xizihgpsajethyy.ipfs.nftstorage.link,true
 Fluid USDC,fUSDC,Ez2zVjw85tZan1ycnJ5PywNNxR6Gm4jbXQtZKyQNu3Lv,6,https://static.fluidity.money/images/tokens/fUSDC.png,true
 Wen,WEN,WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk,5,https://shdw-drive.genesysgo.net/GwJapVHVvfM4Mw4sWszkzywncUWuxxPd6s9VuFfXRgie/wen_logo.png,true
-MS PAINT,PAINT,8x9c5qa4nvakKo5wHPbPa5xvTVMKmS26w4DRpCQLCLk3,9,https://imgur.com/a/0QNFi0J.png,true
+MS PAINT,PAINT,8x9c5qa4nvakKo5wHPbPa5xvTVMKmS26w4DRpCQLCLk3,9,https://i.imgur.com/t7CeL6E.png,true
 PELFORT,$PELF,BgJW7U1u2RY5XJk9uYb5AqFRzjMtqE7pw3kaf9iw9Ntz,6,https://raw.githubusercontent.com/yamitora0/pelfort/main/logo.png,true
 YOM,YOM,yomFPUqz1wJwYSfD5tZJUtS3bNb8xs8mx9XzBv8RL39,9,https://yom.mypinata.cloud/ipfs/QmQ9qE5XWMEyzQGWJFcZjwjigHBzSWDaaf2xFhCFqdvUcx,true
 Colana,COL,B4cYZYVYeHgLc3W1pCduCYkoS75G6roPaPdPoBCFweNJ,9,https://www.arweave.net/hj3JN-bVGRs0ytJmxtXkL3vswXnPHfRAGOUNTNyyg8g,true


### PR DESCRIPTION
PAINT has started appearing in the Jupiter Strict list, but the image is not loading. Could it be that the imgur URL we have in the csv is not working for Jupiter? In this commit, I have changed the image URL to use a direct link to the PAINT image file hosted on the i.imgur.com subdomain, instead of using the imgur.com domain.

Updated image url: https://i.imgur.com/t7CeL6E.png

Here is a link to the original PR: https://github.com/jup-ag/token-list/pull/1238

Please let me know if you need anything else from the PAINT community to make the image load for us in the Strict list. Thanks!