### PR TITLE
ADD Tyson't Tiger (TTIGER) to Strict List

### DIFF
--- a/ADD Tyson't Tiger (TTIGER) to Strict List
+++ b/ADD Tyson't Tiger (TTIGER) to Strict List
@@ -1,0 +1,28 @@
+
+# Validate [TTIGER](https://solscan.io/token/H1C5T6BnmbkBacLCaYoczxFQ7qB5Ggx85hJFAL2HHNBj)
+
+## Attestations (Please provide links):
+https://x.com/tysonstiger69/status/1780038194995572966
+https://twitter.com/tysonstiger69/with_replies
+@tysontiger69 (main)
+@coachbarry18 (Dev/Founder)
+
+Telegram https://t.me/TTIGERMikeTyson
+
+CG Application in and approval pending
+- Coingecko/ CMC URL (If available): https://www.coingecko.com/en/coins/YOUR_ID_HERE
+
+## Validation (Please check off boxes):
+- [ X] The metadata provided in the PR matches what is on-chain (Mandatory)
+- [ X] Does not duplicate the symbol of another token on Jupiter's strict list (If not, review will be delayed)
+- [X ] Is Listed on Coingecko / CMC (Optional, but helpful for reviewers)  
+
+## Acknowledgement (Please check off boxes)
+- [X ] My change matches the format in the file (no spaces between fields).
+- [X ] My token is already live and trading on Jupiter.
+- [ ] !!! I read the README section on Community-Driven Validation and understand this PR will be only be reviewed when there is community support on Twitter.
+- [X] Please make sure your pull request title has your token name. If it just says "Main", or "Validate", it will automatically be closed. PRs containing broken attestation or solscan links will also be closed.
+
+![Screenshot 2024-04-15 225126](https://github.com/jup-ag/token-list/assets/167147918/b351c9d5-8220-4e72-ab46-0b666d208179)
+![support1](https://github.com/jup-ag/token-list/assets/167147918/1de32fec-7ce0-4ad0-82b9-65dd484bd350)
+ 


### PR DESCRIPTION
I tried doing this in the Strict List page but it kept failing saying I am not a collaborator. Please help if this is again not right


# Validate [TTIGER](https://solscan.io/token/H1C5T6BnmbkBacLCaYoczxFQ7qB5Ggx85hJFAL2HHNBj)

## Attestations (Please provide links):
https://x.com/tysonstiger69/status/1780038194995572966
https://twitter.com/tysonstiger69/with_replies
@tysontiger69 (main)
@coachbarry18 (Dev/Founder)

Telegram https://t.me/TTIGERMikeTyson

CG Application in and approval pending
- Coingecko/ CMC URL (If available): https://www.coingecko.com/en/coins/YOUR_ID_HERE

## Validation (Please check off boxes):
- [ X] The metadata provided in the PR matches what is on-chain (Mandatory)
- [ X] Does not duplicate the symbol of another token on Jupiter's strict list (If not, review will be delayed)
- [X ] Is Listed on Coingecko / CMC (Optional, but helpful for reviewers)  

## Acknowledgement (Please check off boxes)
- [X ] My change matches the format in the file (no spaces between fields).
- [X ] My token is already live and trading on Jupiter.
- [ ] !!! I read the README section on Community-Driven Validation and understand this PR will be only be reviewed when there is community support on Twitter.
- [X] Please make sure your pull request title has your token name. If it just says "Main", or "Validate", it will automatically be closed. PRs containing broken attestation or solscan links will also be closed.

![Screenshot 2024-04-15 225126](https://github.com/jup-ag/token-list/assets/167147918/b351c9d5-8220-4e72-ab46-0b666d208179)
![support1](https://github.com/jup-ag/token-list/assets/167147918/1de32fec-7ce0-4ad0-82b9-65dd484bd350)
 
