### PR TITLE
fix(Validate Boden): Updating URL for thumbnail

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -1245,7 +1245,7 @@ Dragon,MuShu,CF97pGa5aNhXYkERsYLbAZ1wyk6cSFrfKhd1ansRD3So,10,https://bafybeiesfk
 HUND,HUND,2XPqoKfJitk8YcMDGBKy7CMzRRyF2X9PniZeCykDUZev,9,https://ipfs.io/ipfs/QmVMuMjyfKkuVnb8rHFXYor1ezFp9xrecatMH7TizPWdKV,true
 Devour,DPAY,Gnca3UkjR4a1FFNZuGfEELmbaHkL6GteSC2swpdWRmf7,8,https://tokens.debridge.finance/0x39b22d4e4dd2668575e36ed9ce554a1ed4a436f4cce8777c450ec0fc5187cb5e.png,true
 Snoopy,$SNOOPY,4LP5JKsyKC5pSAoodwcZnDCSK2ggsMcZvHKoo7HCPDCV,9,https://bafkreih5phb36g46nyomg3gx6274wyhbgh4pyhax7noxpbhinirxtzcyum.ipfs.nftstorage.link,true
-jeo boden,boden,3psH1Mj1f7yUfaD5gh6Zj7epE8hhrMkMETgv5TshQA4o,9,https://bafkreid2t4f3i36tq4aowwaaa5633ggslefthxfdudaimog6unwu36umha.ipfs.nftstorage.link/,true
+jeo boden,boden,3psH1Mj1f7yUfaD5gh6Zj7epE8hhrMkMETgv5TshQA4o,9,https://moccasin-changing-deer-546.mypinata.cloud/ipfs/QmbGN4tMwqjUYNYSAzYpVs4s5v6xgouSKpZpFt1MC7tW24,true
 ansom,ANSOM,BfHkvKMEYjwPXnL36uiM8RnAoMFy8aqNyTJXYU3ZnZtz,6,https://cf-ipfs.com/ipfs/QmXWnsBLVqSwfKn7zr89HJDb9HSAqHCQQE4eoTSd69qmYe,true
 DooDoo (Wormhole),doodoo,JDwzFSxcUvLubUb9xAuuZNvh4bbcEJcuM9TezpmRHVWF,8,https://nftstorage.link/ipfs/bafybeidyutrgtbcw2oxfajdty7kyd3slwqbxval2itdfingeop4324cdjy,true
 Ada,ADA,E4Q5pLaEiejwEQHcM9GeYSQfMyGy8DJ4bPWgeYthn24v,9,https://gateway.irys.xyz/BFejxwOQrFxDnvG84t8kUf3PI_nCU3PEBrHBlu6g5ww,true


### PR DESCRIPTION
# Validate [Boden](https://solscan.io/token/3psH1Mj1f7yUfaD5gh6Zj7epE8hhrMkMETgv5TshQA4o)

## Attestations (Please provide links):
- [Link to Previous PR](https://github.com/jup-ag/token-list/pull/2088)

## Validation (Please check off boxes):
- [x] The metadata provided in the PR matches what is on-chain (Mandatory)

☝️ This is no longer the case as the image in the token's metadata does not render on JUP (as well as Raydium). This PR should fix JUP but the token's metadata would need to be updated to fix Raydium more than likely. Open to ideas here. 

- [x] Does not duplicate the symbol of another token on Jupiter's strict list (If not, review will be delayed)
- [x] Is Listed on Coingecko / CMC (Optional, but helpful for reviewers)  

## Acknowledgement (Please check off boxes)
- [x] My change matches the format in the file (no spaces between fields).
- [x] My token is already live and trading on Jupiter.
- [x] !!! I read the README section on Community-Driven Validation and understand this PR will be only be reviewed when there is community support on Twitter.
- [x] Please make sure your pull request title has your token name. If it just says "Main", or "Validate", it will automatically be closed. PRs containing broken attestation or solscan links will also be closed.