### PR TITLE
Add UCIT token to validated-tokens.csv

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -1462,3 +1462,4 @@ Cloned Sui,clSUI,JzwfZvJGdsqbrKZQUvzJpWhbHcZUix7CYcCaoiNpjxg,8,https://markets.c
 Cloned Arbitrum,clARB,9cMWa1wuWcio3vgEpiFg7PqKbcoafuUw5sLYFkXJ2J8M,8,https://markets.clone.so/images/assets/on-arb.svg,true
 Solboard,Board,4xBEoJFNxRY7ZyUPEFmWwHrGzYN5uqzsAH94DTvBv3b1,6,https://cf-ipfs.com/ipfs/QmY8PoXxkRGCP8giAv5RbCTznDaYyWfYF6xu8RGY3GXdfo,true
 SWOLE,SWOLE,sio28ienC3iABUKJFzkikHknbR3xyhjzhJE34tipyDP,9,https://image-cdn.solana.fm/images/?imageUrl=https://ipfs.io/ipfs/Qmf4Sb9NetKYYUAVGryfAxRXZcLdzkxEpKmoxjV5EvNz9N,true
+UCIT,UCIT,HH8bchogQD71iuLghP4cuvSU7vsGJoMJDBxvWTFu7MpA,2,https://bafkreie6kc5hrewxecaco5v36l5gqcir7b6mbemnlr5tzq2apr77hnpvbq.ipfs.nftstorage.link/,true


### PR DESCRIPTION
Community adds $UCIT (HH8bchogQD71iuLghP4cuvSU7vsGJoMJDBxvWTFu7MpA) to validated-tokens.csv.

# Validate [UCIT](https://solscan.io/token/HH8bchogQD71iuLghP4cuvSU7vsGJoMJDBxvWTFu7MpA)

## Attestations (Please provide links):
- Tweet from your Twitter Account attesting the Mint address, tagging [@JupiterExchange](https://twitter.com/JupiterExchange) and showing community support: https://twitter.com/ucit_official/status/1784995646547669069
- Coingecko/ CMC URL (If available): https://www.coingecko.com/en/coins/ucit

## Validation (Please check off boxes):
- [x] The metadata provided in the PR matches what is on-chain (Mandatory)
- [x] Does not duplicate the symbol of another token on Jupiter's strict list (If not, review will be delayed)
- [x] Is Listed on Coingecko / CMC (Optional, but helpful for reviewers)  

## Acknowledgement (Please check off boxes)
- [x] My change matches the format in the file (no spaces between fields).
- [x] My token is already live and trading on Jupiter.
- [x] !!! I read the README section on Community-Driven Validation and understand this PR will be only be reviewed when there is community support on Twitter.
- [x] Please make sure your pull request title has your token name. If it just says "Main", or "Validate", it will automatically be closed. PRs containing broken attestation or solscan links will also be closed.