### PR TITLE
Update logo for the MIM token

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -1174,7 +1174,7 @@ D2,D2X,GyuP7chtXSRB6erApifBxFvuTtz94x3zQo3JdWofBTgy,3,https://scpri.me/files/log
 $POINTS,$POINTS,9cX8hMxZ2vW7pxYEPf2G5UHrcmMx83iTgGcxwwRKdarq,9,https://bafkreia7w7auilyxmky3ajrozqsdgexi42kakax3iueinz4asyyfumilky.ipfs.nftstorage.link,true
 Just The Tip,$TIPS,AK87oZM8ovFU14bq8mu4ufi5zsCPDbqqVvh5b6WHbUdL,9,https://justthetipvip.com/wp-content/uploads/2024/02/comp-header.png,true
 ZEBU,ZEBU,7unYePWUHcpB28cnS65TpqT2qqmZaftRz9QABkdR8yN7,6,https://bafybeifi5wr2k5giyoikp7hnyx5zsdlt37ez3qzav6y5nssrjzaxuxnedi.ipfs.nftstorage.link,true
-Badger,Badger,9V4x6ikFm9XKsnh3TiYJWPwQfFkJZDjifu7VSUqg3es1,9,https://bafybeid32j2uhizizt77t5au2xekwprplqn2k4thirubwkrvnb2cgadije.ipfs.nftstorage.link,true
+Badger,Badger,9V4x6ikFm9XKsnh3TiYJWPwQfFkJZDjifu7VSUqg3es1,9,https://bafybeifag5dynntf4ek5mnemp7o7qzvvsq5dn5k5qkgj5rswl5dpirkdbe.ipfs.dweb.link,true
 Horse Meat,HorseMeat,2FprjEk4MTSY9CxpKuENbGDdy69R15GHhtHpG5Durdbq,9,https://i.imgur.com/uKfGicj.jpeg,true
 doginthpool,DIP,3XxvmED354933DwSPJuzB7SE9uiWpD1ErydDuhmbFRMk,6,https://bafkreidjc5can5he5bx7qgvbdkrpmgajs3lcaqm6hvixvrceinc5tsaacq.ipfs.nftstorage.link,true
 Robert,ROBERT,AoN2z7w7ccQJQiWS7rjS45dcyYkVkBddXDcrzmj69tqf,3,https://raw.githubusercontent.com/scoops0/Robert-Logo/main/Robert%20Logo.webp,true


### PR DESCRIPTION
We are updating our MIM logo 3 and a half months after the community takeover, as we no longer agree with the logo chosen by the developer.  Our new logo is being deployed on our social networks, CMC, Gecko, Solscan, Dextools, Dexscreener, Birdeye.so , etc ... 

Awaiting approval. 

Best regards,

Blump MIM Council member

![pfp_800x800](https://github.com/jup-ag/token-list/assets/161648136/f75a974a-3761-4fab-9b14-70b15b42a928)
