### PR TITLE
Update logo for the MIM token

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -1151,7 +1151,7 @@ Tanox,LTX,LTXH7nCGXz5TBZ57H8oZu7YwmDSVfSqWViW4B28yg8X,8,https://shdw-drive.genes
 Libra Protocol,LIBRA,Hz1XePA2vukqFBcf9P7VJ3AsMKoTXyPn3s21dNvGrHnd,9,https://bafkreie7gs73rnak3aqft5eipsbtd4rtam3locmddovgls6wdhfzsjbmqq.ipfs.nftstorage.link,true
 :moyai:(MOAI),MOAI,7NQSHjuEGENZDWfSvPZz7oP2D6c5Jc3LjFC6uh179ufr,9,https://node2.irys.xyz/z-DMnyxOt4FgHKdQq-05tIJOyarmt7Tg1QUqUeEOdew,true
 Reward Protocol,REWD,2eu1K3wvfPC7gVj1CK8ohv4ggusdN6qxyxpjHyTCkjZT,6,https://bafkreic2ndn27fumdff4q3qht3a6dq44peoys7bf437n2rlcnci25tzkyi.ipfs.nftstorage.link,true
-Magic Internet Money,MIM,G33s1LiUADEBLzN5jL6ocSXqrT2wsUq9W6nZ8o4k1b4L,9,https://bafkreict6ykbea4qa5ulzkkagkihqqvo33frgaqo4kzofgsuyxxjozcuii.ipfs.nftstorage.link,true
+Magic Internet Money,MIM,G33s1LiUADEBLzN5jL6ocSXqrT2wsUq9W6nZ8o4k1b4L,9,https://bafybeifag5dynntf4ek5mnemp7o7qzvvsq5dn5k5qkgj5rswl5dpirkdbe.ipfs.dweb.link,true
 Edgevana Staked SOL,edgeSOL,edge86g9cVz87xcpKpy3J77vbp4wYd9idEV562CCntt,9,https://arweave.net/JqUwm41OHf2jFLDognx7BKD6N9LiUDDRMTI8k2B7fHE,true
 DONALD,DONALD,4Yz5zByTwnVe46AXD6hsrccbq4TKLyih2xRqPyLBDT1P,6,https://gateway.irys.xyz/LQ9YCmIWoXtDUAxNQhPjpbGbTgLjkgnLFVQJfRn73o0,true
 Any Inu (Wormhole),AI,ACeWC77UeW2DBZMe7YBsuXoxLvk4dHMnPzneApau1Au6,8,https://raw.githubusercontent.com/anyinu/MediaAssets/849ced29c7614ad8193661e7faa8eaece31eb313/ailogo.png,true


### PR DESCRIPTION
We are updating our MIM logo 3 and a half months after the community takeover, as we no longer agree with the logo chosen by the developer. Our new logo is being deployed on our social networks, CMC, Gecko, Solscan, Dextools, Dexscreener, Birdeye.so , etc ...

Awaiting approval.

Best regards,

Blump MIM Council member

![pfp_800x800](https://github.com/jup-ag/token-list/assets/161648136/2d07aa24-43c9-457f-8a64-02c1d9d2b754)
