### PR TITLE
ban fake PICHI

### DIFF
--- a/banned-tokens.csv
+++ b/banned-tokens.csv
@@ -40,3 +40,4 @@ FyPcy9q2oUXta8DyeEG98SWhBsNFDQDFtBniajoMSCpD,fake KMNO
 AuhHd6SJuyoZUQHu5HDCMCcxogCEEKHi9Auu1tUebugn,fake KMNO
 9PqhiAMGSaXvyma193Tt2GBHpvtGcLTZpZZbP8nuNMQ,fake KMNO
 3LDjnhekVVqdxDmhD5vLHg5LfhxfW9naVyG9NfZqs7DT,fake KMNO
+4QYjfQYdhycSRg6ftrcMaMcPTxmHYeeueT8Kux1ehp84,fake PICHI with real CA in name


### PR DESCRIPTION
ban the fake $PICHI, trying to draw users by using the real tokens CA in it's name

real CA: Cp69uioTUrgrRmJdiJL5s6VQ2wguu2GosdFbUYym4XZ3

this fake token's name: Pichi / Cp69uioTUrgrRmJdiJL5s6VQ2wguu2GosdFbUYym4XZ3