### PR TITLE
Update GMCAT image URL

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -1715,6 +1715,6 @@ GCRClassic,GCR,791hZNiCJy1qGSGzAvqUU8X6gejiBJ2mBV8JjYoVnzBR,6,https://cf-ipfs.co
 Mami,Mami,62mALBEzUQWS3r8EzjnX1C2ricdTy9hkv8gs7mLtpump,6,https://cf-ipfs.com/ipfs/QmSmM6GzEdgFSXtgKBNGckrHbBq8abNy5HJpGE2VxEpyzv,true
 AMADEUS,AMADEUS,Eq9xBLGnBc2B6wkdoZW6v1aCC4evtSaNPkSFKaDNQNFr,9,https://bafybeify7x2y6ojvzhtiafc4ovk7eh5vzu2iksyg3p4b7lom657dyym6e4.ipfs.nftstorage.link/,true
 dainSOL,dainSOL,2LuXDpkn7ZWMqufwgUv7ZisggGkSE5FpeHCHBsRgLg3m,9,https://tca2vwit4gdsuwo3evencavzatf6sdit6e3xpiw374fmid45q55q.arweave.net/mIGq2RPhhypZ2yVI0QK5BMvpDRPxN3ei2_8KxA-dh3s,true
-GM Cat,GMCAT,83HDsxuNFnhanLgkTdij3dT7tP5FH3bb1TV1rbTT7atz,6,https://nftstorage.link/ipfs/bafkreihiz4wpdqhvybs6wofhf3y5grnta4v3ex2hi234obgsuszgjvtdzq,true
+GM Cat,GMCAT,83HDsxuNFnhanLgkTdij3dT7tP5FH3bb1TV1rbTT7atz,6,https://bafkreihiz4wpdqhvybs6wofhf3y5grnta4v3ex2hi234obgsuszgjvtdzq.ipfs.nftstorage.link/,true
 BAREBEARS,BAREBEARS,AeNg6DaCAjNpK7CvkSC6c9j5g8YFSp78aTQxejaNRNcz,6,https://bafybeigojiffozmk6hzhbyrwvdiyrq3anyp2otos7p4us7nowkanlhgirq.ipfs.nftstorage.link/,true
 


### PR DESCRIPTION
The reason for this change is that logo is not loading due to redirect.

I checked other entries and they all follow this url pattern for the domain. Sorry for the inconvenience.

- The current URL in `validated-tokens.csv` is `https://nftstorage.link/ipfs/bafkreihiz4wpdqhvybs6wofhf3y5grnta4v3ex2hi234obgsuszgjvtdzq`
- Updated URL: `https://bafkreihiz4wpdqhvybs6wofhf3y5grnta4v3ex2hi234obgsuszgjvtdzq.ipfs.nftstorage.link/`
