### PR TITLE
Add WeAllLoveLatinas (WALL) token

### DIFF
--- a/src/tokens/wall.json
+++ b/src/tokens/wall.json
@@ -1,0 +1,8 @@
+{
+  "name": "WeAllLoveLatinas",
+  "symbol": "WALL",
+  "address": "DthWteZ3Bn1cV5hF22LFVbchgdWuvmnDMp9cRdReoiq",
+  "decimals": 9,
+  "logoURI": "https://raw.githubusercontent.com/xanast/token-list/main/assets/mainnet/DthWteZ3Bn1cV5hF22LFVbchgdWuvmnDMp9cRdReoiq/logo.png",
+  "tags": ["community", "meme", "strict", "pump"]
+}


### PR DESCRIPTION
Added metadata and logo for WALL (WeAllLoveLatinas) token to be listed on Jupiter.

- Mint: `DthWteZ3Bn1cV5hF22LFVbchgdWuvmnDMp9cRdReoiq`
- Symbol: `WALL`
- Decimals: `9`
- Logo: 200x200 PNG hosted on GitHub
- Tags: `community`, `meme`, `strict`, `pump`

## Attestation
Tweet from official account (community proof):  
👉 https://x.com/WALL_solana 

## Checklist ✅
- [x] The metadata provided matches what is on-chain
- [x] This is not a duplicate of another token
- [x] My token is live and trading on Jupiter
- [x] File format is correct
