### PR TITLE
Update validated-tokens.csv

### DIFF
--- a/validated-tokens.csv
+++ b/validated-tokens.csv
@@ -779,3 +779,4 @@ Purple Pepe,PURPE,HBoNJ5v8g71s2boRivrHnfSB5MVPLDHHyVjruPfhGkvL,1,https://statics
 BAKED,BAKED,CQbXk942c6GPcRwtZ2WMFP5JcQ9NqbXtb8jUewBi7GoT,6,https://raw.githubusercontent.com/Baked-Resources/solana-token/main/baked_logo.jpg,true
 Send,SEND,SENDdRQtYMWaQrBroBrJ2Q53fgVuq95CV9UPGEvpCxa,6,https://tgnrqry5tpxb5imfstlqu2mdqpm3zwmmaxrrakjxuinvpwhkanca.arweave.net/mZsYRx2b7h6hhZTXCmmDg9m82YwF4xApN6IbV9jqA0Q,true
 Cloud,CLOUD,CLoUDKc4Ane7HeQcPpE3YHnznRxhMimJ4MyaUqyHFzAu,9,https://arweave.net/N7vCgQdgQ-fab28zEB4m8QRLMwI91_KcXI-Gtr151gg,true
+Mintify,MINT,AvoecWraqX969kfXUF5XCCDz59sjRjiDa1KUDyj225t8,9,https://arweave.net/U62-ES63pPC_cu1iXHiaX0w2fPns3iEOuOLskWXTxpU,false


### PR DESCRIPTION
Birdeye are not pulling the validated tokens by using the `validated` tag, but rather by asking for `strict,community,lst`. While they fix this they're not correctly getting this Mintify token, CA AvoecWraqX969kfXUF5XCCDz59sjRjiDa1KUDyj225t8.

This PR is to give the correct behaviour in the short term.
